### PR TITLE
Fixes to oppg2.5 and 3.4

### DIFF
--- a/assignments/assignment02/assignment02.ipynb
+++ b/assignments/assignment02/assignment02.ipynb
@@ -719,7 +719,7 @@
     "\n",
     "Både SVM og MLP har over 90 % treffsikkerhet, men MLP scorer litt høyere på alle metrikker. Derfor anbefaler vi MLP.\n",
     "\n",
-    "Macro F1-Score og Macro ROC-AUC behandler alle klasser likt, uavhengig av hvor mange samples klassen har i datasettet. Macro F1-Score håndterer derfor ujevn fordeling bedre enn Test Accuracy og Weighted F1-Score, som begge påvirkes sterkt av majoritetsklassene. Derfor gir Macro-verdiene et mer korrekt bilde av ytelsen enn Test Accuracy og Weighted F1-Score.\n"
+    "Macro F1-Score og Macro ROC-AUC behandler alle klasser likt, uavhengig av hvor mange samples klassen har i datasettet. Macro F1-Score håndterer derfor ofte ujevn fordeling bedre enn Test Accuracy og Weighted F1-Score, som begge påvirkes sterkt av majoritetsklassene. Macro-metrikker kan derfor gi et mer balansert bilde av ytelsen når alle klasser anses som like viktige og datasettet er skjevt fordelt, mens Weighted F1-Score og Test Accuracy kan være mer hensiktsmessige når man bevisst vil vekte etter forekomst.\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary by Sourcery

Clarify the analysis and explanation sections for selected exercises in assignment 2, improving the justification of model choice and metric selection while cleaning up minor formatting.

Enhancements:
- Expand the written comparison of SVM and MLP models to include a clearer recommendation based on the reported evaluation metrics.
- Add an explanation of why macro-averaged F1 and ROC-AUC provide a more reliable performance picture than accuracy and weighted F1 when classes are imbalanced.
- Tidy notebook cell outputs by removing superfluous blank lines in explanation and results tables.